### PR TITLE
Remove explicit Navx reference. 

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,7 +8,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/CTRLib.jar"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/navx_frc.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Montclair Robotics/navx-mxp/java/lib/navx_frc.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/Sprocket"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Navx library must be in the ...\user\java\lib directory. Fixes #6 