### PR TITLE
Create a "standard" robot class that will always be the one that gets deployed…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 def TEAM = 555
-def ROBOT_CLASS = "frc.team555.robot.TankRobot"
+def ROBOT_CLASS = "frc.team555.robot.Robot"
 
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project EmbeddedTools.

--- a/src/main/java/frc/team555/robot/Robot.java
+++ b/src/main/java/frc/team555/robot/Robot.java
@@ -1,0 +1,4 @@
+package frc.team555.robot;
+
+public class Robot extends TankRobot {
+}


### PR DESCRIPTION
… This class should extend whatever "real" class you want to deploy. It allows the selection of robot code to run to be made in the "software" instead of in the gradle setup. I think this leaves the options "at the top".