### PR TITLE
Updated to GradleRIO 2018-1-6b

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id "eclipse"
     id "idea"
-    id "jaci.openrio.gradle.GradleRIO" version "2018.01.06"
+    id "jaci.openrio.gradle.GradleRIO" version "2018.01.06b"
 }
 
 def TEAM = 555


### PR DESCRIPTION
New version has a few bugfix changes for Shuffleboard and new JRE deployment.